### PR TITLE
Updated website's URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ BIMSie for BIM in the cloud
 ======
 
 The BIM Service interface exchange (BIMSie) standard API for BIM in the cloud.
-This repo hold the documentation source tht is viewable on http://bimsie.openbimstandards.org
+This repo holds the documentation source that is viewable on http://buildingsmart.github.io/BIMSie-API/
 
 More info about BIMSie is available on http://www.nibs.org/?page=bsa_bimsie
 


### PR DESCRIPTION
The URL was broken, updated to http://buildingsmart.github.io/BIMSie-API/
